### PR TITLE
feat: Use p-queue for global email throttling and retry on 429s in sendAirQualityAlerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.483.0",
+        "p-queue": "^8.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.4.1",
@@ -3170,6 +3171,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
@@ -4405,6 +4412,34 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1",
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.483.0",
+    "p-queue": "^8.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.4.1",


### PR DESCRIPTION
### Summary

This PR addresses issues with hitting the Resend API rate limit (HTTP 429 errors) when sending air quality alert emails in batch via the cron job. The previous implementation attempted to delay between emails, but this was not effective in a serverless environment or when multiple batches were processed in parallel.

### Changes

- **Global Throttling with p-queue:**  
  Replaces per-email `setTimeout` with a global queue using [`p-queue`](https://www.npmjs.com/package/p-queue), ensuring no more than 2 emails are sent per second, regardless of how many ZIP codes or subscriptions are processed.
- **Retry Logic for 429 Errors:**  
  Adds exponential backoff retry logic for emails that fail with a 429 rate limit error (up to 3 retries per email).
- **Dependency:**  
  Adds `p-queue` to the project dependencies.

### Why

- **Reliability:**  
  Prevents hitting the Resend API’s rate limit, ensuring all emails are delivered as expected.
- **Correctness:**  
  Guarantees throttling is respected globally, not just within a single batch or ZIP code.
- **Resilience:**  
  Retries failed emails with backoff, improving delivery success rate.

### How

- All outgoing emails are added to a single `PQueue` instance.
- The queue is configured to allow 2 emails per second (`interval: 1000, intervalCap: 2`).
- If a 429 error is encountered, the email send is retried with exponential backoff (up to 3 times).

### Testing

- [ ] Confirmed that emails are sent at the correct rate in production/staging.
- [ ] Verified that 429 errors are retried and eventually succeed or fail gracefully.

---

**Closes:** #<issue-number-if-applicable>  
**Reviewer Notes:**  
Please check that the new throttling logic works as expected