### PR TITLE
feat: add Vercel Analytics integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@trpc/server": "^10.45.1",
         "@upstash/ratelimit": "^2.0.5",
         "@upstash/redis": "^1.34.9",
+        "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.483.0",
@@ -2177,6 +2178,44 @@
       "license": "MIT",
       "dependencies": {
         "crypto-js": "^4.2.0"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@trpc/server": "^10.45.1",
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.34.9",
+    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.483.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App.tsx";
 import AdminPage from "./pages/AdminPage.tsx";
 import { UnsubscribePage } from "./pages/UnsubscribePage.tsx";
 import { ThemeProvider } from "./lib/theme";
+import { Analytics } from "@vercel/analytics/react";
 
 const router = createBrowserRouter([
   {
@@ -26,6 +27,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
       <RouterProvider router={router} />
+      <Analytics />
     </ThemeProvider>
   </StrictMode>
 );


### PR DESCRIPTION
This PR adds Vercel Analytics to the app using the official @vercel/analytics package.
- Installs @vercel/analytics.
- Adds the <Analytics /> component at the root of the app (in main.tsx) as per [Vercel Analytics Quickstart](https://vercel.com/docs/analytics/quickstart#add-the-analytics-component-to-your-app).

Once merged and deployed, analytics data will be available in the Vercel dashboard.