### PR TITLE
fix: support dark mode for AQI card using Card component

### DIFF
--- a/src/components/AQICard.tsx
+++ b/src/components/AQICard.tsx
@@ -1,3 +1,5 @@
+import { Card, CardHeader, CardTitle, CardContent } from "./ui/card";
+
 interface AQICardProps {
   index: number;
   category: string;
@@ -18,13 +20,17 @@ const formatPollutant = (pollutant: string): string => {
 
 export function AQICard({ index, category, dominantPollutant }: AQICardProps) {
   return (
-    <div className="bg-white p-4 rounded-lg shadow">
-      <h2 className="text-xl font-semibold mb-2">Air Quality Information</h2>
-      <p className="text-lg">AQI: {index}</p>
-      <p className="text-lg">Category: {category}</p>
-      <p className="text-lg">
-        Dominant Pollutant: {formatPollutant(dominantPollutant)}
-      </p>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle>Air Quality Information</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-lg">AQI: {index}</p>
+        <p className="text-lg">Category: {category}</p>
+        <p className="text-lg">
+          Dominant Pollutant: {formatPollutant(dominantPollutant)}
+        </p>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
## Fix: Dark Mode Support for AQI Card

This PR addresses [#23](https://github.com/narulaskaran/aqi-monitor/issues/23):

- Refactors the `AQICard` component to use the reusable `Card`, `CardHeader`, `CardTitle`, and `CardContent` components from `ui/card.tsx`.
- Removes hardcoded background and text colors, ensuring the card adapts to both light and dark themes using the project's Tailwind and shadcn/ui system.
- The AQI card now renders correctly in dark mode, matching the rest of the UI.

**Tested:**

- Light and dark mode both render the AQI card with appropriate background and text colors.

---

Closes #23.
