### PR TITLE
fix(test): stub localStorage/sessionStorage for Node 22+ compatibility

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,42 @@
 import "@testing-library/jest-dom";
 
+// Node 22+ exposes a global `localStorage` whose methods throw (or are
+// missing) unless Node is started with --localstorage-file. That global
+// shadows jsdom's implementation, so install an in-memory stub that works
+// regardless of Node version.
+const createStorageMock = (): Storage => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+};
+
+for (const target of [globalThis, globalThis.window] as const) {
+  Object.defineProperty(target, "localStorage", {
+    value: createStorageMock(),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(target, "sessionStorage", {
+    value: createStorageMock(),
+    writable: true,
+    configurable: true,
+  });
+}
+
 // Mock window.matchMedia for jsdom
 globalThis.window.matchMedia =
   globalThis.window.matchMedia ||


### PR DESCRIPTION
## Summary
- Node 22+ ships a global `localStorage` whose methods throw unless Node is started with `--localstorage-file`. That global shadows jsdom's implementation, so running the test suite on modern Node fails 40 tests (CI on Node 20 is unaffected).
- Installs in-memory `Storage` stubs for `localStorage` and `sessionStorage` in `src/setupTests.ts` so tests pass deterministically on any Node version.

## Test plan
- `npm test` on Node 25: 26 files / 80 tests pass (previously 15 files / 40 tests failing)
- `npm run typecheck` and `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)