### PR TITLE
feat: subscription management list for signed-in users

### DIFF
--- a/api/__tests__/subscriptionsApi.test.ts
+++ b/api/__tests__/subscriptionsApi.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import handler from "../subscriptions.js";
+import { mockRes, mockSubscription } from "./testUtils.js";
+
+// Mock auth middleware
+vi.mock("../_lib/middleware/auth.js", () => ({
+  authenticate: vi.fn(),
+}));
+
+// Mock subscription service
+vi.mock("../_lib/services/subscription.js", () => ({
+  getSubscriptionsForEmailSorted: vi.fn(),
+  setSubscriptionActive: vi.fn(),
+}));
+
+// Mock prisma
+vi.mock("../_lib/db.js", () => ({
+  prisma: {
+    userSubscription: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("GET /api/subscriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when auth fails", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockRejectedValue(new Error("Unauthorized"));
+
+    const req: any = { method: "GET", headers: {} };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
+  });
+
+  it("returns subscriptions sorted correctly", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockResolvedValue({ email: "user@example.com" });
+
+    const { getSubscriptionsForEmailSorted } = await import(
+      "../_lib/services/subscription.js"
+    );
+    const sorted = [
+      { ...mockSubscription, active: true, zipCode: "11111" },
+      { ...mockSubscription, active: false, zipCode: "22222" },
+    ];
+    (getSubscriptionsForEmailSorted as any).mockResolvedValue(sorted);
+
+    const req: any = { method: "GET", headers: {} };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      subscriptions: sorted,
+    });
+    expect(getSubscriptionsForEmailSorted).toHaveBeenCalledWith("user@example.com");
+  });
+});
+
+describe("PATCH /api/subscriptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when auth fails", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockRejectedValue(new Error("Unauthorized"));
+
+    const req: any = { method: "PATCH", headers: {}, body: { id: "sub-1", active: false } };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("returns 404 when subscription not found", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockResolvedValue({ email: "user@example.com" });
+
+    const db = await import("../_lib/db.js");
+    (db.prisma.userSubscription.findUnique as any).mockResolvedValue(null);
+
+    const req: any = {
+      method: "PATCH",
+      headers: {},
+      body: { id: "nonexistent", active: false },
+    };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ error: "Subscription not found" });
+  });
+
+  it("returns 403 when subscription belongs to another user", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockResolvedValue({ email: "user@example.com" });
+
+    const db = await import("../_lib/db.js");
+    (db.prisma.userSubscription.findUnique as any).mockResolvedValue({
+      ...mockSubscription,
+      email: "other@example.com",
+    });
+
+    const req: any = {
+      method: "PATCH",
+      headers: {},
+      body: { id: "sub-1", active: false },
+    };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "Forbidden" });
+  });
+
+  it("updates subscription active status successfully", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockResolvedValue({ email: "user@example.com" });
+
+    const db = await import("../_lib/db.js");
+    (db.prisma.userSubscription.findUnique as any).mockResolvedValue({
+      ...mockSubscription,
+      email: "user@example.com",
+    });
+
+    const { setSubscriptionActive } = await import(
+      "../_lib/services/subscription.js"
+    );
+    const updatedSub = { ...mockSubscription, active: false, email: "user@example.com" };
+    (setSubscriptionActive as any).mockResolvedValue(updatedSub);
+
+    const req: any = {
+      method: "PATCH",
+      headers: {},
+      body: { id: mockSubscription.id, active: false },
+    };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      subscription: updatedSub,
+    });
+    expect(setSubscriptionActive).toHaveBeenCalledWith(mockSubscription.id, false);
+  });
+});
+
+describe("Unsupported methods", () => {
+  it("returns 405 for DELETE", async () => {
+    const { authenticate } = await import("../_lib/middleware/auth.js");
+    (authenticate as any).mockResolvedValue({ email: "user@example.com" });
+
+    const req: any = { method: "DELETE", headers: {}, body: {} };
+    const res = mockRes();
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});

--- a/api/_lib/services/subscription.ts
+++ b/api/_lib/services/subscription.ts
@@ -188,6 +188,34 @@ export async function findSubscriptionsForEmail(
 }
 
 /**
+ * Returns all subscriptions for an email, ordered active-first then most recently updated
+ */
+export async function getSubscriptionsForEmailSorted(
+  email: string,
+): Promise<Subscription[]> {
+  return await prisma.userSubscription.findMany({
+    where: { email },
+    orderBy: [{ active: "desc" }, { updatedAt: "desc" }],
+  });
+}
+
+/**
+ * Updates the active status of a subscription by ID.
+ * When activating, also sets activatedAt to now.
+ */
+export async function setSubscriptionActive(
+  id: string,
+  active: boolean,
+): Promise<Subscription> {
+  return await prisma.userSubscription.update({
+    where: { id },
+    data: active
+      ? { active: true, activatedAt: new Date() }
+      : { active: false },
+  });
+}
+
+/**
  * Checks if a subscription already exists
  */
 export async function subscriptionExists(

--- a/api/subscriptions.ts
+++ b/api/subscriptions.ts
@@ -1,0 +1,67 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { authenticate } from "./_lib/middleware/auth.js";
+import { prisma } from "./_lib/db.js";
+import {
+  getSubscriptionsForEmailSorted,
+  setSubscriptionActive,
+} from "./_lib/services/subscription.js";
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  // Authenticate every request
+  let email: string;
+  try {
+    const auth = await authenticate(req);
+    email = auth.email;
+  } catch {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // GET /api/subscriptions — list all subscriptions for the authenticated user
+  if (req.method === "GET") {
+    try {
+      const subscriptions = await getSubscriptionsForEmailSorted(email);
+      return res.json({ success: true, subscriptions });
+    } catch (error) {
+      console.error("Error fetching subscriptions:", error);
+      return res.status(500).json({ error: "Failed to fetch subscriptions" });
+    }
+  }
+
+  // PATCH /api/subscriptions — toggle active status for a subscription
+  if (req.method === "PATCH") {
+    try {
+      const { id, active } = req.body as { id: string; active: boolean };
+
+      if (!id || typeof active !== "boolean") {
+        return res
+          .status(400)
+          .json({ error: "id (string) and active (boolean) are required" });
+      }
+
+      // Look up the subscription to verify ownership
+      const subscription = await prisma.userSubscription.findUnique({
+        where: { id },
+      });
+
+      if (!subscription) {
+        return res.status(404).json({ error: "Subscription not found" });
+      }
+
+      if (subscription.email !== email) {
+        return res.status(403).json({ error: "Forbidden" });
+      }
+
+      const updated = await setSubscriptionActive(id, active);
+      return res.json({ success: true, subscription: updated });
+    } catch (error) {
+      console.error("Error updating subscription:", error);
+      return res.status(500).json({ error: "Failed to update subscription" });
+    }
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
 import "./App.css";
 import { useState, ChangeEvent, useEffect } from "react";
 import { SubscriptionForm } from "./components/SubscriptionForm";
+import { SubscriptionList } from "./components/SubscriptionList";
 import { getAirQuality } from "./lib/api";
 import { ThemeToggle } from "./components/ThemeToggle";
 import AuthWidget from "./components/AuthWidget";
@@ -121,6 +122,7 @@ function App() {
             <SubscriptionForm zipCode={currentZipCode} />
           </>
         )}
+        <SubscriptionList />
       </div>
 
       {/* Move AuthWidget to the bottom, above Admin/Ko-Fi */}

--- a/src/components/AuthWidget.tsx
+++ b/src/components/AuthWidget.tsx
@@ -1,63 +1,23 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { isValidEmail } from "../lib/utils";
 import {
   InputOTP,
   InputOTPGroup,
   InputOTPSlot,
 } from "./ui/input-otp";
-
-const AUTH_TOKEN_KEY = "aqi_auth_token";
+import { useAuth } from "../lib/auth";
 
 export default function AuthWidget() {
+  const { isSignedIn, email: authEmail, isValidating, signIn, signOut } = useAuth();
+
   const [email, setEmail] = useState("");
   const [showModal, setShowModal] = useState(false);
   const [step, setStep] = useState<"email" | "code">("email");
-  const [isSignedIn, setIsSignedIn] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isValidatingToken, setIsValidatingToken] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [otp, setOtp] = useState("");
 
   const verifyButtonRef = useRef<HTMLButtonElement>(null);
-
-  // Restore original useEffect for token validation
-  useEffect(() => {
-    const token = localStorage.getItem(AUTH_TOKEN_KEY);
-    if (!token) {
-      setIsValidatingToken(false);
-      return;
-    }
-    setIsValidatingToken(true);
-    fetch("/api/validate-token", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error("Invalid token");
-        return res.json();
-      })
-      .then((data) => {
-        if (data.valid) {
-          setIsSignedIn(true);
-          if (data.email) setEmail(data.email);
-        } else {
-          localStorage.removeItem(AUTH_TOKEN_KEY);
-          setIsSignedIn(false);
-          setEmail("");
-        }
-      })
-      .catch(() => {
-        localStorage.removeItem(AUTH_TOKEN_KEY);
-        setIsSignedIn(false);
-        setEmail("");
-      })
-      .finally(() => {
-        setIsValidatingToken(false);
-      });
-  }, []);
 
   const handleSignIn = () => {
     setShowModal(true);
@@ -105,8 +65,7 @@ export default function AuthWidget() {
       const data = await res.json();
       if (!data.success || !data.token)
         throw new Error(data.error || "Invalid code");
-      localStorage.setItem(AUTH_TOKEN_KEY, data.token);
-      setIsSignedIn(true);
+      signIn(data.token, email);
       setShowModal(false);
     } catch (err: unknown) {
       setError((err as Error).message || "Failed to verify code");
@@ -116,15 +75,9 @@ export default function AuthWidget() {
     }
   };
 
-  const handleSignOut = () => {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
-    setIsSignedIn(false);
-    setEmail("");
-  };
-
   return (
     <div className="flex items-center space-x-2">
-      {isValidatingToken ? (
+      {isValidating ? (
         <span className="text-gray-500 dark:text-gray-400 text-sm">
           Loading...
         </span>
@@ -192,17 +145,6 @@ export default function AuthWidget() {
                         value={otp}
                         onChange={(value) => {
                           setOtp(value);
-                          if (value.length === 6) {
-                            // Use a timeout to allow state update before submission if needed,
-                            // but direct call is usually fine.
-                            // However, verifyButtonRef click is safer to trigger form submission
-                            // naturally or just call the handler.
-                            // Given the UI has a button, let's let the user click or
-                            // auto-submit if desired. The original code auto-submitted.
-                            if (value.length === 6) {
-                                // Optional: auto-submit
-                            }
-                          }
                         }}
                         onComplete={() => verifyButtonRef.current?.click()}
                       >
@@ -258,14 +200,14 @@ export default function AuthWidget() {
             </span>
             <span
               className="text-sm font-medium text-gray-900 dark:text-gray-100 leading-tight truncate max-w-[120px]"
-              title={email}
+              title={authEmail}
             >
-              {email}
+              {authEmail}
             </span>
           </div>
           <button
             className="ml-2 px-2 py-1 text-xs rounded-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-700 transition"
-            onClick={handleSignOut}
+            onClick={signOut}
             title="Sign Out"
           >
             Sign Out

--- a/src/components/SubscriptionList.tsx
+++ b/src/components/SubscriptionList.tsx
@@ -21,7 +21,7 @@ interface PendingToggle {
 }
 
 export function SubscriptionList() {
-  const { isSignedIn, token } = useAuth();
+  const { isSignedIn, token, signOut } = useAuth();
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -36,11 +36,18 @@ export function SubscriptionList() {
       const data = await getSubscriptions(token);
       setSubscriptions(data.subscriptions ?? []);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load subscriptions");
+      const message =
+        err instanceof Error ? err.message : "Failed to load subscriptions";
+      // Expired/invalid session: clear it so the user can sign in again
+      if (message.includes("401")) {
+        signOut();
+        return;
+      }
+      setError(message);
     } finally {
       setIsLoading(false);
     }
-  }, [token]);
+  }, [token, signOut]);
 
   useEffect(() => {
     if (isSignedIn) {
@@ -97,7 +104,7 @@ export function SubscriptionList() {
         </p>
       )}
 
-      {subscriptions.length > 0 && (
+      {!isLoading && subscriptions.length > 0 && (
         <ul className="space-y-2">
           {subscriptions.map((sub) => (
             <li

--- a/src/components/SubscriptionList.tsx
+++ b/src/components/SubscriptionList.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect, useCallback } from "react";
+import { useAuth } from "../lib/auth";
+import { getSubscriptions, updateSubscription } from "../lib/api";
+import { Button } from "./ui/button";
+
+interface Subscription {
+  id: string;
+  zipCode: string;
+  active: boolean;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+  activatedAt: string | null;
+  lastEmailSentAt: string | null;
+  expiresAt: string | null;
+}
+
+interface PendingToggle {
+  id: string;
+  currentActive: boolean;
+}
+
+export function SubscriptionList() {
+  const { isSignedIn, token } = useAuth();
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingToggle, setPendingToggle] = useState<PendingToggle | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const fetchSubscriptions = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getSubscriptions(token);
+      setSubscriptions(data.subscriptions ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load subscriptions");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (isSignedIn) {
+      fetchSubscriptions();
+    }
+  }, [isSignedIn, fetchSubscriptions]);
+
+  if (!isSignedIn) return null;
+
+  const handleToggleClick = (sub: Subscription) => {
+    setPendingToggle({ id: sub.id, currentActive: sub.active });
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingToggle || !token) return;
+    setIsUpdating(true);
+    try {
+      await updateSubscription(token, pendingToggle.id, !pendingToggle.currentActive);
+      setPendingToggle(null);
+      await fetchSubscriptions();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update subscription");
+      setPendingToggle(null);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setPendingToggle(null);
+  };
+
+  const pendingSub = pendingToggle
+    ? subscriptions.find((s) => s.id === pendingToggle.id)
+    : null;
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">
+        Your Subscriptions
+      </h2>
+
+      {isLoading && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
+      )}
+
+      {error && (
+        <p className="text-sm text-red-500 mb-2">{error}</p>
+      )}
+
+      {!isLoading && !error && subscriptions.length === 0 && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No subscriptions yet.
+        </p>
+      )}
+
+      {subscriptions.length > 0 && (
+        <ul className="space-y-2">
+          {subscriptions.map((sub) => (
+            <li
+              key={sub.id}
+              className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 px-4 py-3"
+            >
+              <div className="flex items-center gap-3">
+                <span className="font-mono text-sm text-gray-900 dark:text-gray-100">
+                  {sub.zipCode}
+                </span>
+                {sub.active ? (
+                  <span className="inline-flex items-center rounded-full bg-green-100 dark:bg-green-900 px-2 py-0.5 text-xs font-medium text-green-800 dark:text-green-200">
+                    Active
+                  </span>
+                ) : (
+                  <span className="inline-flex items-center rounded-full bg-gray-100 dark:bg-gray-700 px-2 py-0.5 text-xs font-medium text-gray-600 dark:text-gray-400">
+                    Inactive
+                  </span>
+                )}
+              </div>
+              <Button
+                size="sm"
+                variant={sub.active ? "destructive" : "default"}
+                onClick={() => handleToggleClick(sub)}
+              >
+                {sub.active ? "Deactivate" : "Reactivate"}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Confirmation modal */}
+      {pendingToggle && pendingSub && (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-lg shadow-lg p-6 w-80 relative">
+            <h3 className="text-lg font-semibold mb-3">Confirm</h3>
+            <p className="text-sm mb-5">
+              {pendingSub.active
+                ? `Deactivate subscription for ZIP code ${pendingSub.zipCode}?`
+                : `Reactivate subscription for ZIP code ${pendingSub.zipCode}?`}
+            </p>
+            <div className="flex gap-2 justify-end">
+              <Button variant="outline" size="sm" onClick={handleCancel} disabled={isUpdating}>
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                variant={pendingSub.active ? "destructive" : "default"}
+                onClick={handleConfirm}
+                disabled={isUpdating}
+              >
+                {isUpdating ? "Saving..." : "Confirm"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/SubscriptionList.test.tsx
+++ b/src/components/__tests__/SubscriptionList.test.tsx
@@ -1,0 +1,173 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "../../lib/test-utils";
+import { SubscriptionList } from "../SubscriptionList";
+import * as authModule from "../../lib/auth";
+import * as apiModule from "../../lib/api";
+
+// Mock the auth module
+vi.mock("../../lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof authModule>();
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+  };
+});
+
+// Mock the API module
+vi.mock("../../lib/api", () => ({
+  getSubscriptions: vi.fn(),
+  updateSubscription: vi.fn(),
+  getAirQuality: vi.fn(),
+  startVerification: vi.fn(),
+  verifyCode: vi.fn(),
+  getBaseUrl: vi.fn(),
+  getApiUrl: vi.fn(),
+}));
+
+const mockSubscriptions = [
+  {
+    id: "sub-1",
+    zipCode: "10001",
+    active: true,
+    email: "user@example.com",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-02T00:00:00Z",
+    activatedAt: "2024-01-01T00:00:00Z",
+    lastEmailSentAt: null,
+    expiresAt: null,
+  },
+  {
+    id: "sub-2",
+    zipCode: "90210",
+    active: false,
+    email: "user@example.com",
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    activatedAt: null,
+    lastEmailSentAt: null,
+    expiresAt: null,
+  },
+];
+
+describe("SubscriptionList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when signed out", () => {
+    (authModule.useAuth as any).mockReturnValue({
+      isSignedIn: false,
+      token: null,
+      email: "",
+      isValidating: false,
+    });
+
+    const { container } = render(<SubscriptionList />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders subscription list when signed in", async () => {
+    (authModule.useAuth as any).mockReturnValue({
+      isSignedIn: true,
+      token: "test-token",
+      email: "user@example.com",
+      isValidating: false,
+    });
+
+    (apiModule.getSubscriptions as any).mockResolvedValue({
+      success: true,
+      subscriptions: mockSubscriptions,
+    });
+
+    render(<SubscriptionList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("10001")).toBeInTheDocument();
+      expect(screen.getByText("90210")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /deactivate/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reactivate/i })).toBeInTheDocument();
+  });
+
+  it("opens confirmation modal on toggle click and confirms", async () => {
+    (authModule.useAuth as any).mockReturnValue({
+      isSignedIn: true,
+      token: "test-token",
+      email: "user@example.com",
+      isValidating: false,
+    });
+
+    (apiModule.getSubscriptions as any).mockResolvedValue({
+      success: true,
+      subscriptions: mockSubscriptions,
+    });
+
+    (apiModule.updateSubscription as any).mockResolvedValue({
+      success: true,
+      subscription: { ...mockSubscriptions[0], active: false },
+    });
+
+    render(<SubscriptionList />);
+
+    // Wait for list to load
+    await waitFor(() => {
+      expect(screen.getByText("10001")).toBeInTheDocument();
+    });
+
+    // Click the deactivate button for sub-1
+    fireEvent.click(screen.getByRole("button", { name: /deactivate/i }));
+
+    // Confirmation modal should appear
+    expect(screen.getByText(/Deactivate subscription for ZIP code 10001/i)).toBeInTheDocument();
+
+    // Click Confirm
+    fireEvent.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(apiModule.updateSubscription).toHaveBeenCalledWith(
+        "test-token",
+        "sub-1",
+        false,
+      );
+    });
+
+    // Modal should be gone
+    await waitFor(() => {
+      expect(screen.queryByText(/Deactivate subscription for ZIP code 10001/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes modal on cancel without calling updateSubscription", async () => {
+    (authModule.useAuth as any).mockReturnValue({
+      isSignedIn: true,
+      token: "test-token",
+      email: "user@example.com",
+      isValidating: false,
+    });
+
+    (apiModule.getSubscriptions as any).mockResolvedValue({
+      success: true,
+      subscriptions: mockSubscriptions,
+    });
+
+    render(<SubscriptionList />);
+
+    await waitFor(() => {
+      expect(screen.getByText("10001")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /deactivate/i }));
+    expect(screen.getByText(/Deactivate subscription for ZIP code 10001/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Deactivate subscription for ZIP code 10001/i)).not.toBeInTheDocument();
+    });
+
+    expect(apiModule.updateSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -96,6 +96,44 @@ export async function startVerification(email: string, zipCode: string) {
 }
 
 /**
+ * Fetches all subscriptions for the authenticated user
+ */
+export async function getSubscriptions(token: string) {
+  const response = await fetch(getApiUrl("subscriptions"), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch subscriptions: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Toggles the active status of a subscription
+ */
+export async function updateSubscription(
+  token: string,
+  id: string,
+  active: boolean,
+) {
+  const response = await fetch(getApiUrl("subscriptions"), {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ id, active }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to update subscription: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
  * Verifies code sent to email
  */
 export async function verifyCode(

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+} from "react";
+
+const AUTH_TOKEN_KEY = "aqi_auth_token";
+
+interface AuthState {
+  isSignedIn: boolean;
+  email: string;
+  token: string | null;
+  isValidating: boolean;
+}
+
+interface AuthContextValue extends AuthState {
+  signIn: (token: string, email: string) => void;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthState>({
+    isSignedIn: false,
+    email: "",
+    token: null,
+    isValidating: true,
+  });
+
+  useEffect(() => {
+    const token = localStorage.getItem(AUTH_TOKEN_KEY);
+    if (!token) {
+      setState((s) => ({ ...s, isValidating: false }));
+      return;
+    }
+
+    fetch("/api/validate-token", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Invalid token");
+        return res.json();
+      })
+      .then((data) => {
+        if (data.valid) {
+          setState({
+            isSignedIn: true,
+            email: data.email ?? "",
+            token,
+            isValidating: false,
+          });
+        } else {
+          localStorage.removeItem(AUTH_TOKEN_KEY);
+          setState({ isSignedIn: false, email: "", token: null, isValidating: false });
+        }
+      })
+      .catch(() => {
+        localStorage.removeItem(AUTH_TOKEN_KEY);
+        setState({ isSignedIn: false, email: "", token: null, isValidating: false });
+      });
+  }, []);
+
+  const signIn = (token: string, email: string) => {
+    localStorage.setItem(AUTH_TOKEN_KEY, token);
+    setState({ isSignedIn: true, email, token, isValidating: false });
+  };
+
+  const signOut = () => {
+    localStorage.removeItem(AUTH_TOKEN_KEY);
+    setState({ isSignedIn: false, email: "", token: null, isValidating: false });
+  };
+
+  return (
+    <AuthContext.Provider value={{ ...state, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return ctx;
+}

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -3,8 +3,10 @@ import {
   useContext,
   useState,
   useEffect,
+  useCallback,
   ReactNode,
 } from "react";
+import { getApiUrl } from "./api";
 
 const AUTH_TOKEN_KEY = "aqi_auth_token";
 
@@ -37,7 +39,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       return;
     }
 
-    fetch("/api/validate-token", {
+    fetch(getApiUrl("validate-token"), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
@@ -67,15 +69,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       });
   }, []);
 
-  const signIn = (token: string, email: string) => {
+  const signIn = useCallback((token: string, email: string) => {
     localStorage.setItem(AUTH_TOKEN_KEY, token);
     setState({ isSignedIn: true, email, token, isValidating: false });
-  };
+  }, []);
 
-  const signOut = () => {
+  const signOut = useCallback(() => {
     localStorage.removeItem(AUTH_TOKEN_KEY);
     setState({ isSignedIn: false, email: "", token: null, isValidating: false });
-  };
+  }, []);
 
   return (
     <AuthContext.Provider value={{ ...state, signIn, signOut }}>

--- a/src/lib/test-utils.tsx
+++ b/src/lib/test-utils.tsx
@@ -1,11 +1,17 @@
 import { ReactNode } from "react";
 import { render, RenderOptions } from "@testing-library/react";
 import { ThemeProvider } from "./theme";
+import { AuthProvider } from "./auth";
 import { MemoryRouter } from "react-router-dom";
 
-// Custom render with ThemeProvider
+// Custom render with ThemeProvider and AuthProvider
 const renderWithTheme = (ui: ReactNode, options?: RenderOptions) =>
-  render(<ThemeProvider>{ui}</ThemeProvider>, options);
+  render(
+    <ThemeProvider>
+      <AuthProvider>{ui}</AuthProvider>
+    </ThemeProvider>,
+    options,
+  );
 
 // Custom render with ThemeProvider and MemoryRouter
 interface RouterOptions extends RenderOptions {
@@ -16,7 +22,9 @@ const renderWithRouter = (ui: ReactNode, options?: RouterOptions) => {
   const { initialEntries = ["/"], ...rest } = options || {};
   return render(
     <ThemeProvider>
-      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+      <AuthProvider>
+        <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+      </AuthProvider>
     </ThemeProvider>,
     rest,
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from "./App.tsx";
 import AdminPage from "./pages/AdminPage.tsx";
 import { UnsubscribePage } from "./pages/UnsubscribePage.tsx";
 import { ThemeProvider } from "./lib/theme";
+import { AuthProvider } from "./lib/auth";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 
@@ -27,9 +28,11 @@ const router = createBrowserRouter([
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
-      <RouterProvider router={router} />
-      <Analytics />
-      <SpeedInsights />
+      <AuthProvider>
+        <RouterProvider router={router} />
+        <Analytics />
+        <SpeedInsights />
+      </AuthProvider>
     </ThemeProvider>
   </StrictMode>
 );

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,42 @@
 import "@testing-library/jest-dom";
 
+// Node 22+ exposes a global `localStorage` whose methods throw (or are
+// missing) unless Node is started with --localstorage-file. That global
+// shadows jsdom's implementation, so install an in-memory stub that works
+// regardless of Node version.
+const createStorageMock = (): Storage => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+};
+
+for (const target of [globalThis, globalThis.window] as const) {
+  Object.defineProperty(target, "localStorage", {
+    value: createStorageMock(),
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(target, "sessionStorage", {
+    value: createStorageMock(),
+    writable: true,
+    configurable: true,
+  });
+}
+
 // Mock window.matchMedia for jsdom
 globalThis.window.matchMedia =
   globalThis.window.matchMedia ||


### PR DESCRIPTION
## Summary

- Add `GET + PATCH /api/subscriptions` endpoint (auth via Bearer token) — GET returns sorted subscriptions (active first, then most recently updated), PATCH verifies ownership before toggling `active` / `activatedAt`
- Add `getSubscriptionsForEmailSorted` and `setSubscriptionActive` service functions in `api/_lib/services/subscription.ts`
- Introduce `AuthProvider` + `useAuth()` hook in `src/lib/auth.tsx`; refactor `AuthWidget` to consume the context (identical UI/behavior)
- New `SubscriptionList` component: fetches and renders all subscriptions for the signed-in user with ZIP code, active/inactive badge, and a Deactivate/Reactivate button guarded by a confirmation modal
- `<SubscriptionList />` is rendered in `App.tsx` outside the `{airQuality && ...}` block so it always shows when signed in
- `getSubscriptions` and `updateSubscription` helpers added to `src/lib/api.ts`
- `AuthProvider` wraps `<RouterProvider>` in `src/main.tsx`

## Test plan

- [x] `npm test` — 91 tests pass (80 baseline + 11 new)
- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — 0 errors, 1 pre-existing warning
- [x] `api/__tests__/subscriptionsApi.test.ts`: auth failure (401), GET ordering, PATCH 404/403 ownership checks, PATCH success, 405 for unsupported methods
- [x] `src/components/__tests__/SubscriptionList.test.tsx`: hidden when signed out, renders list with ZIP/status/buttons, confirm modal flow triggers PATCH, cancel closes modal without calling API

## Notes

- Closes #17
- **This PR must merge AFTER PR #42** (fix/node-25-localstorage-tests) — it branches from that fix and depends on the test-environment localStorage stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)