### PR TITLE
fix: align README with daily cron schedule (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A real-time Air Quality Index (AQI) monitoring application that allows users to 
 
 ## Features
 
-- Real-time air quality data using Google Air Quality API
+- Daily air quality data using Google Air Quality API
 - Color-coded AQI display with category and health recommendations
 - Email alerts for poor air quality conditions
 - ZIP code based monitoring and alerts
-- Hourly air quality data storage
+- Daily air quality data storage
 - Responsive design for desktop and mobile
 - Admin dashboard for managing data
 


### PR DESCRIPTION
Closes #51.

## What
Updates the README to accurately describe the cron schedule. The Vercel Hobby (free) plan limits cron jobs to **once per day** — hourly expressions (like `0 * * * *`) are rejected at deployment time.

### Changes
- "Real-time air quality data" → "Daily air quality data"
- "Hourly air quality data storage" → "Daily air quality data storage"

## Why
The actual cron schedule in `vercel.json` is `0 0 * * *` (daily at midnight UTC), which is the maximum allowed frequency on the Hobby plan. The README claims of hourly/real-time updates were misleading.

No code changes were needed — the 20-hour email gate in `subscription.ts` and the daily cron are already consistent. Users get one data fetch and one alert per day.

## Testing
- `npm test`: all 115 tests pass across 30 test files
- Verified Vercel docs confirm Hobby plan minimum interval is once per day

---

🤖 Draft by Hermes — review required, will not auto-merge.