### PR TITLE
docs: move VITE_API_URL from Frontend to Backend/API section (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ JWT_SECRET="your_jwt_secret"
 
 #### Backend / API
 
+Also add the following to the same `.env` file:
+
 ```env
-# Base URL for unsubscribe links in alert emails
-VITE_API_URL="http://localhost:3000"
+# Base URL for unsubscribe links in alert emails (production only)
+VITE_API_URL="https://your-app.vercel.app"
 ```
 
 ### Installation and Local Development

--- a/README.md
+++ b/README.md
@@ -54,8 +54,12 @@ GOOGLE_AIR_QUALITY_API_KEY="your_google_api_key"
 # Admin access
 CRON_SECRET="your_cron_job_secret"
 JWT_SECRET="your_jwt_secret"
+```
 
-# Frontend
+#### Backend / API
+
+```env
+# Base URL for unsubscribe links in alert emails
 VITE_API_URL="http://localhost:3000"
 ```
 


### PR DESCRIPTION
Closes #65.

## What

Moves `VITE_API_URL` out of the Frontend env vars section into its own **Backend / API** subsection in `README.md`, with a clearer comment explaining its actual purpose (building unsubscribe links in alert emails).

## Why

`VITE_API_URL` is never read by any `src/` (frontend) code — it is only used server-side in `api/_lib/services/subscription.ts` to build unsubscribe URLs in email alerts. Listing it under "Frontend" misleads developers who set it only in their Vite build environment, resulting in broken unsubscribe links.

Flagged by Claude during PR #61 review.

## Testing

- [x] Verified `VITE_API_URL` usage: only in `api/_lib/services/subscription.ts` and `api/__tests__/subscription.test.ts` — no frontend (`src/`) references.
- [x] All `119` existing tests pass (`31` test files).
- [x] Reviewed final README rendering.

---

🤖 Draft by Hermes — review required, will not auto-merge.