### PR TITLE
fix: forecast API 400 error from exact-horizon boundary

### DIFF
--- a/api/air-quality-forecast.ts
+++ b/api/air-quality-forecast.ts
@@ -56,9 +56,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       });
     }
 
+    // Google's API rejects a period whose start/end sits exactly on "now" or
+    // the 96-hour horizon: by the time our request reaches Google (after the
+    // coordinates lookup + network latency), its own clock has moved past our
+    // computed `now`/`horizonEnd`, making the boundary invalid ("The specified
+    // time period is not supported"). Pad both edges inward so the period we
+    // actually send stays safely within Google's window.
+    const BOUNDARY_BUFFER_MS = 5 * 60 * 1000;
+    const usableStart = new Date(now.getTime() + BOUNDARY_BUFFER_MS);
+    const usableEnd = new Date(horizonEnd.getTime() - BOUNDARY_BUFFER_MS);
+
     // Clamp requested window to the available horizon
-    const clampedStart = parsedStart < now ? now : parsedStart;
-    const clampedEnd = parsedEnd > horizonEnd ? horizonEnd : parsedEnd;
+    const clampedStart = parsedStart < usableStart ? usableStart : parsedStart;
+    const clampedEndRaw = parsedEnd > usableEnd ? usableEnd : parsedEnd;
+    const clampedEnd = clampedEndRaw < clampedStart ? clampedStart : clampedEndRaw;
 
     console.log(`Forecast request for ZIP: ${zipCode}, ${startDate} – ${endDateStr}`);
 


### PR DESCRIPTION
## Summary

- Fixes a 400 error from Google's Air Quality forecast lookup API (`INVALID_ARGUMENT: The specified time period is not supported`) that reproduces whenever the forecast form's default date range (today → today+4) is submitted.
- Root cause: the backend clamped the requested period to exactly `[now, now + 96h]`, but by the time the outbound request reaches Google (after a DB coordinate lookup + network latency), real time has moved past that boundary, causing it to reject the period.
- Fix: pad both edges of the clamp inward by 5 minutes so the period sent to Google stays safely within its window. The existing "is this range even within 4 days" validation (and its error message) is unchanged.

## Test plan

- [x] Traced the exact failing request from the reported Vercel logs against the new clamping logic by hand
- [ ] Run `npm test` to confirm forecast test suite passes
- [ ] Manually retry the forecast form with default dates against the real Google API in a deploy preview

Note: This is unrelated to the original "4-day subscription limit" report from the issue body — as noted in the earlier investigation, subscription scheduling has no such limit; the 4-day cap belongs to the separate forecast preview widget and mirrors Google's own forecast horizon.

Fixes #72
